### PR TITLE
Added client application functionality of the Job Manager Service

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"log"
+
+	"github.com/astronomical3/jobmgr/client"
+)
+
+// Path relative to the root client activity logging directory path (which is 'jobmgr/client/clientlogs/')
+const clientLogFilepath = "client.log"
+
+func main() {
+	// Create a ClientLoggingObject to start logging different activity throughout the client application.
+	clientLogger := client.NewClientLoggingObject(clientLogFilepath)
+
+	// Create a new CLI object that will then take in the flags of the `go run [jobmgr/]client.go` command.
+	cliObj := client.NewCli(clientLogger)
+	cliObj.LoadFlagsAndParseCmd()
+	err := cliObj.SubmitJob()
+	if err != nil {
+		log.Printf("CLI object's SubmitJob operation ended in error: %v", err)
+	}
+}

--- a/client/client_callback.go
+++ b/client/client_callback.go
@@ -8,3 +8,414 @@ import (
 	"github.com/astronomical3/jobmgr/jobmgrcapnp"
 )
 
+
+//****************************************************************************
+// Definition of the JobCallbackHandler struct that is used for creating
+//   a job-specific log, and logging job-specific activity in that job
+//   log file for historical references and for monitoring.
+type JobCallbackHandler struct {
+	jobName      string
+	jobId        string
+	process      string
+	status       jobmgrcapnp.Status
+	clientLogger *ClientLoggingObject
+	doneChan     chan struct{}
+}
+
+// Constructor function for creating a new JobCallbackHandler that 
+//   eventually will be controlled by the Job Manager service.
+func NewJobCallbackHandler(
+	jobName string, 
+	process string, 
+	clientLogger *ClientLoggingObject,
+) *JobCallbackHandler {
+	return &JobCallbackHandler{
+		jobName: jobName,
+		process: process,
+		clientLogger: clientLogger,
+		doneChan: make(chan struct{}),
+	}
+}
+
+// Implementation of the jobmgrcapnp.JobCallback_initialUpdateJobInfo() RPC,
+//   which uses arguments (namely the "jobid" and "status" parameters) to add
+//   the values to populate remaining empty fields of the JobCallbackHandler,
+//   and also use the jobId to create a job log file dedicated specifically to
+//   a run of the submitted job using the clientLogger.
+func (jch *JobCallbackHandler) InitialUpdateJobInfo(
+	ctx context.Context,
+	call jobmgrcapnp.JobCallback_initialUpdateJobInfo,
+) error {
+	// Obtain all arguments from the server
+	args := call.Args()
+	jobName, err := args.Jobname()
+	if err != nil {
+		jch.clientLogger.ClientLogError(
+			"rpc",
+			"jobmgrcapnp.JobCallback_jobFailed",
+			fmt.Sprintf(
+				"Failed to receive job name: %v",
+				err,
+			),
+		)
+		return err
+	}
+	jobId, err := args.JobId()
+	if err != nil {
+		jch.clientLogger.ClientLogError(
+			"rpc",
+			"jobmgrcapnp.JobCallback_jobFailed",
+			fmt.Sprintf(
+				"Failed to receive job name: %v",
+				err,
+			),
+		)
+		return err
+	}
+	process, err := args.Process()
+	if err != nil {
+		jch.clientLogger.ClientLogError(
+			"rpc",
+			"jobmgrcapnp.JobCallback_jobFailed",
+			fmt.Sprintf(
+				"Failed to receive job name: %v",
+				err,
+			),
+		)
+		return err
+	}
+
+	
+	jch.jobName = jobName
+	jch.jobId = jobId
+	jch.process = process
+
+	// Get the current time and convert it to a readable string format to
+	//   string format to include in the job log file name.
+	currentTime := time.Now()
+	datetimeString := fmt.Sprintf(
+		"%d-%d-%d_%d%d",
+		currentTime.Year(),
+		currentTime.Month(),
+		currentTime.Day(),
+		currentTime.Hour(),
+		currentTime.Minute(),
+	)
+
+	// Create the job log file name.
+	jobLogFilename := fmt.Sprintf(
+		"%s-%s-%s.log", 
+		jch.jobName, 
+		jch.jobId, 
+		datetimeString,
+	)
+
+	// Log in the client activity logs that the log file is being created.
+	jch.clientLogger.ClientLogInfo(
+		"rpc",
+		"jobmgrcapnp.JobCallback_initialUpdateJobInfo",
+		fmt.Sprintf("Creating new job log file %s", jobLogFilename),
+	)
+
+	jch.clientLogger.AddJobLog(jch.jobId, jobLogFilename)
+	jch.clientLogger.JobLogInfo(
+		jch.jobId,
+		"process",
+		jch.process,
+		fmt.Sprintf(
+			"Process has started for job '%s', with jobId '%s'.",
+			jch.jobName,
+			jch.jobId,
+		),
+	)
+	jch.clientLogger.ClientLogInfo(
+		"rpc",
+		"jobmgrcapnp.JobCallback_initialUpdateJobInfo",
+		fmt.Sprintf(
+			"Process '%s' has started for job '%s', with jobId '%s'",
+			jch.process,
+			jch.jobName,
+			jch.jobId,
+		),
+	)
+	return nil
+}
+
+// Implementation of the jobmgrcapnp.JobCallback_updateJobLog() RPC, which
+//   may or may not be used multiple times throighout the execution of the 
+//   process, and simply sends back a message for the clientLogger to add 
+//   to the job log file, as well as the overall client activity logs.
+func (jch *JobCallbackHandler) UpdateJobLog(
+	ctx context.Context,
+	call jobmgrcapnp.JobCallback_updateJobLog,
+) error {
+	// Obtain the log message sent from the server
+    logMsg, err := call.Args().LogMsg()
+	if err != nil {
+		jch.clientLogger.JobLogError(
+			jch.jobId,
+			"process",
+			jch.process,
+			fmt.Sprintf("Failed to receive log message: %v", err),
+		)
+		jch.clientLogger.ClientLogError(
+			"rpc",
+			"jobmgrcapnp.JobCallback_updateJobLog",
+			fmt.Sprintf(
+				"Failed to receive log message from process '%s': %v",
+				jch.process,
+				err,
+			),
+		)
+		return err
+	}
+
+	// Add the log message to both the job file log and overall client 
+	//   activity logs.
+	jch.clientLogger.JobLogInfo(jch.jobId, "process", jch.process, logMsg)
+	jch.clientLogger.ClientLogInfo(
+		"rpc", 
+		"jobmgrcapnp.JobCallback_updateJobLog",
+		fmt.Sprintf(
+			"Received log message from process '%s' in job '%s' (job ID %s)",
+			jch.process,
+			jch.jobName,
+			jch.jobId,
+		),
+	)
+	jch.clientLogger.ClientLogInfo("jobId", jch.jobId, logMsg)
+
+	return nil
+}
+
+// Implementation of the jobmgrcapnp.JobCallback_updateStatus() RPC, which may
+//   or may not be used multiple times throughout the execution of the process,
+//   and simply sends back the Status enum of "exec" (enum 1), in order to ensure
+//   the client that the job's requested process has either begun running or is 
+//   still running.
+func (jch *JobCallbackHandler) UpdateStatus(
+	ctx context.Context,
+	call jobmgrcapnp.JobCallback_updateStatus,
+) error {
+	// Obtain the status enum sent from the server.
+	status := call.Args().Status()
+	
+	jch.clientLogger.ClientLogInfo(
+		"rpc",
+		"jobmgrcapnp.JobCallback_updateStatus",
+		fmt.Sprintf(
+			"Process '%s' in job '%s' (job ID %s) set to 'exec' status",
+			jch.process,
+			jch.jobName,
+			jch.jobId,
+		),
+	)
+
+	// Add the status to the JobCallbackHandler.status field.
+	jch.status = status
+	return nil
+}
+
+// Implementation of the jobmgrcapnp.JobCallback_jobSuccessful() RPC, which
+//   is called only at the end of the process if it is successful.  Logs that 
+//   the job was successful, and receives the "success" status (enum 2) to add 
+//   into the status field of the JobCallbackHandler.
+func (jch *JobCallbackHandler) JobSuccessful(
+	ctx context.Context,
+	call jobmgrcapnp.JobCallback_jobSuccessful,
+) error {
+	// Obtain all arguments from the server
+	args := call.Args()
+	logMsg, err := args.LogMsg()
+	if err != nil {
+		jch.clientLogger.JobLogError(
+			jch.jobId,
+			"process",
+			jch.process,
+			fmt.Sprintf("Failed to receive log message: %v", err),
+		)
+		jch.clientLogger.ClientLogError(
+			"rpc",
+			"jobmgrcapnp.JobCallback_jobSuccessful",
+			fmt.Sprintf(
+				"Failed to receive log message from process '%s': %v",
+				jch.process,
+				err,
+			),
+		)
+		return err
+	}
+	successStatus := args.Status()
+
+	jch.clientLogger.JobLogInfo(jch.jobId, "process", jch.process, logMsg)
+	jch.clientLogger.ClientLogInfo(
+		"rpc",
+		"jobmgrcapnp.JobCallback_jobSuccessful",
+		fmt.Sprintf(
+			"SUCCESS: Final log message from process '%s' in job %s (job ID %s): %s",
+			jch.process,
+			jch.jobName,
+			jch.jobId,
+			logMsg,
+		),
+	)
+
+	jch.clientLogger.ClientLogInfo(
+		"rpc",
+		"jobmgrcapnp.JobCallback_jobSuccessful",
+		fmt.Sprintf(
+			"Setting status of job %s (job ID %s) to 'success'",
+			jch.jobName,
+			jch.jobId,
+		),
+	)
+
+	jch.status = successStatus
+
+	close(jch.doneChan)
+
+	return nil
+}
+
+// Implementation of the jobmgrcapnp.JobCallback_jobFailed() RPC, which is
+//   called only if some part of the process failed.  Logs the job error,
+//   and receives the "error" status (enum 3) to add into the status field
+//   of the JobCallbackHandler.
+func (jch *JobCallbackHandler) JobFailed(
+	ctx context.Context,
+	call jobmgrcapnp.JobCallback_jobFailed,
+) error {
+	// Obtain all arguments from the server
+	args := call.Args()
+	logMsg, err := args.LogMsg()
+	if err != nil {
+		jch.clientLogger.JobLogError(
+			jch.jobId,
+			"process",
+			jch.process,
+			fmt.Sprintf("Failed to receive log message: %v", err),
+		)
+		jch.clientLogger.ClientLogError(
+			"rpc",
+			"jobmgrcapnp.JobCallback_jobFailed",
+			fmt.Sprintf(
+				"Failed to receive log message from process '%s': %v",
+				jch.process,
+				err,
+			),
+		)
+		return err
+	}
+	errorStatus := args.Status()
+
+	jch.clientLogger.JobLogError(
+		jch.jobId,
+		"process",
+		jch.process,
+		fmt.Sprintf(
+			"FAILED: Job '%s' (job ID %s) ended with error :%s",
+			jch.jobName,
+			jch.jobId,
+			logMsg,
+		),
+	)
+	jch.clientLogger.ClientLogError(
+		"rpc",
+		"jobmgrcapnp.JobCallback_jobFailed",
+		fmt.Sprintf(
+			"JOB FAILED: Process '%s' in job '%s' (job ID %s) ended in error, message: %s",
+			jch.process,
+			jch.jobName,
+			jch.jobId,
+			logMsg,
+		),
+	)
+
+	jch.clientLogger.ClientLogInfo(
+		"rpc",
+		"jobmgrcapnp.JobCallback_jobFailed",
+		fmt.Sprintf(
+			"Setting status of job '%s' (job ID %s) to 'error'",
+			jch.jobName,
+			jch.jobId,
+		),
+	)
+
+	jch.status = errorStatus
+	
+	close(jch.doneChan)
+
+	return nil
+}
+
+// Implementation of the jobmgrcapnp.JobCallback_jobCancelled() RPC, which 
+//   is only called if the client decides to cancel the RPC, or the timeout
+//   context set by the client is timed out.  Logs that the job was cancelled
+//   by the client, and sets the status field in the JobCallbackHandler to 
+//   "cancel" (enum 4).
+func (jch *JobCallbackHandler) JobCancelled(
+	ctx context.Context,
+	call jobmgrcapnp.JobCallback_jobCancelled,
+) error {
+	// Obtain all arguments from the server
+	args := call.Args()
+	logMsg, err := args.LogMsg()
+	if err != nil {
+		jch.clientLogger.JobLogError(
+			jch.jobId,
+			"process",
+			jch.process,
+			fmt.Sprintf("Failed to receive log message: %v", err),
+		)
+		jch.clientLogger.ClientLogError(
+			"rpc",
+			"jobmgrcapnp.JobCallback_jobCancelled",
+			fmt.Sprintf(
+				"Failed to receive log message from process '%s': %v",
+				jch.process,
+				err,
+			),
+		)
+		return err
+	}
+	cancelStatus := args.Status()
+
+	jch.clientLogger.JobLogWarn(
+		jch.jobId,
+		"process",
+		jch.process,
+		fmt.Sprintf(
+			"CANCELLATION WARNING: Job '%s' (job ID %s) cancelled: %s",
+			jch.jobName,
+			jch.jobId,
+			logMsg,
+		),
+	)
+	jch.clientLogger.ClientLogWarn(
+		"rpc",
+		"jobmgrcapnp.JobCallback_jobCancelled",
+		fmt.Sprintf(
+			"JOB CANCELLATION WARNING: Process '%s' in job '%s' (job ID %s) was cancelled, cause was: %s",
+			jch.process,
+			jch.jobName,
+			jch.jobId,
+			logMsg,
+		),
+	)
+
+	jch.clientLogger.ClientLogInfo(
+		"rpc",
+		"jobmgrcapnp.JobCallback_jobFailed",
+		fmt.Sprintf(
+			"Setting status of job '%s' (job ID %s) to 'cancel'",
+			jch.jobName,
+			jch.jobId,
+		),
+	)
+
+	jch.status = cancelStatus
+
+	close(jch.doneChan)
+
+	return nil
+}

--- a/client/client_callback.go
+++ b/client/client_callback.go
@@ -236,6 +236,7 @@ func (jch JobCallbackHandler) JobSuccessful(
 	ctx context.Context,
 	call jobmgrcapnp.JobCallback_jobSuccessful,
 ) error {
+	defer jch.clientLogger.JobLogClose(jch.jobId)
 	// Obtain all arguments from the server
 	args := call.Args()
 	logMsg, err := args.LogMsg()
@@ -303,6 +304,7 @@ func (jch JobCallbackHandler) JobFailed(
 	ctx context.Context,
 	call jobmgrcapnp.JobCallback_jobFailed,
 ) error {
+	defer jch.clientLogger.JobLogClose(jch.jobId)
 	// Obtain all arguments from the server
 	args := call.Args()
 	logMsg, err := args.LogMsg()
@@ -381,6 +383,7 @@ func (jch JobCallbackHandler) JobCancelled(
 	ctx context.Context,
 	call jobmgrcapnp.JobCallback_jobCancelled,
 ) error {
+	defer jch.clientLogger.JobLogClose(jch.jobId)
 	// Obtain all arguments from the server
 	args := call.Args()
 	logMsg, err := args.LogMsg()

--- a/client/client_cli.go
+++ b/client/client_cli.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"flag"
+	"fmt"
+)
+
+//********************************************************************************
+// Definition of the object supporting an execution of the command for submitting
+//   a job into the Cap'n Proto Job Manager Service using the command-line
+//   interface.
+type Cli struct {
+	// For connection to server using "addr" and "port" flags.
+	address      *string
+	port         *int
+
+	// For logging CLI object activity in the client activity logs.
+	clientLogger *ClientLoggingObject
+
+	// For passing actual job information from the flags to the request stub,
+	//   representing the individual job to submit.
+	jobName      *string
+	process      *string
+	timeout      *int
+}
+
+// Constructor function that creates a new instance of a Cli object.  The
+//   first object added to the CLI command object is an instance of a 
+//   *ClientLoggingObject so that it can log its own activity, and also
+//   pass the pointer to this object down to the core ClientRequestObject
+//   (and objects that core struct has access to, such as job callback 
+//   handler).
+func NewCli(clientLogger *ClientLoggingObject) *Cli {
+	return &Cli{clientLogger: clientLogger}
+}
+
+// Method of the Cli object that loads the values of the flags of the `go run [jobmgr/client/]main.go` command.
+func (cli *Cli) LoadFlagsAndParseCmd() {
+	// Loading address and port flag values for connecting to the Job Manager Service server.
+	cli.address = flag.String("addr", "localhost", "address of the Job Manager Service server")
+	cli.port = flag.Int("port", 50051, "port of the Job Manager Service server")
+
+	// Loading job submission information for the actual job submission procedure.
+	cli.jobName = flag.String("jobname", "sampleJob", "user-defined name of the job to submit to, and run on, the Job Manager Service server")
+	cli.process = flag.String("process", "countTo10", "actual process that the submitted job will run on the Job Manager Service server")
+	cli.timeout = flag.Int("timeout", 0, "maximum number of seconds the client will wait before it decides to cancel the job.  0 means run job to completion.")
+
+	flag.Parse()
+}
+
+// Method of the Cli object that actually performs the submit job procedure by creating a 
+//   jobmgrcapnp.JobSubmitInfo struct, then a ClientRequestObject, then uses the 
+//   ClientRequestObject's methods to first ConnectToServer() then SubmitJob().  Error will
+//   be returned from either of those 2 methods.  (ClientRequestObject methods 
+//   should be able to take care of the closings of its resources by itself, using its own
+//   Close() method.)
+func (cli *Cli) SubmitJob() error {
+	// CLI object creates a jobmgrcapnp.JobSubmitInfo struct.
+	cli.clientLogger.ClientLogInfo(
+		"method",
+		"Cli.SubmitJob",
+		fmt.Sprintf(
+			"Creating a jobmgrcapnp.JobSubmitInfo struct for job '%s', which will run process '%s'",
+			*cli.jobName,
+			*cli.process,
+		),
+	)
+	
+	// CLI object creates a ClientRequestObject to pass along the job submission info
+	//   and create a new request to submit a new job into the Job Manager Service 
+	//   server.  This object is the CORE client object, as this actually connects to 
+	//   the server and submit and monitor the job.
+	clientRequest := NewRequest(
+		*cli.jobName,
+		*cli.process,
+		*cli.address,
+		string(rune(*cli.port)),
+		*cli.timeout,
+		cli.clientLogger,
+	)
+
+	// New core client object now connects to the JobManagerService server.  The
+	//   ClientLoggerObject will log any error at the ConnectToServer() level, and
+	//   the CLI object here just receives back either an error (if connection error
+	//   occurs) or a nil error (if connection is successful).
+	err := clientRequest.ConnectToServer()
+	if err != nil {
+		return err
+	}
+
+	// New core client object now actually submits the job into the Job Manager 
+	//   Service server, and monitors the job as the server continues to return
+	//   back occasionally any log messages regarding progress of the job.  The
+	//   client object will log any error at the SubmitJob() level, and the CLI
+	//   object here just receives back the error.
+	err = clientRequest.SubmitJob()
+	if err != nil {
+		return err
+	}
+
+	// A nil error indicates the entire job submission process by the core client
+	//   object went successfully.
+	return nil
+}

--- a/client/client_logger.go
+++ b/client/client_logger.go
@@ -9,39 +9,41 @@ import (
 	"github.com/go-kit/log/level"
 )
 
-//*************************************************************************************
+// *************************************************************************************
 // Definition of the ClientLoggingObject struct, which different parts of the client
-//   application (e.g., a ClientRequestObject, a JobCallbackHandler) can send their 
-//   log messages to, to pass responsibility of logging all client activity -- 
-//   including special log files separate from the client terminal and file logs for
-//   each individual submitted job -- to one object.  That way, duplicate log messages
-//   for the client activity terminal and file logs are written here, and even all 
-//   logging for each job the client submits can be performed by this one object, on
-//   behalf of the other components of the client application that need to log in an
-//   acitivity.
+//
+//	application (e.g., a ClientRequestObject, a JobCallbackHandler) can send their
+//	log messages to, to pass responsibility of logging all client activity --
+//	including special log files separate from the client terminal and file logs for
+//	each individual submitted job -- to one object.  That way, duplicate log messages
+//	for the client activity terminal and file logs are written here, and even all
+//	logging for each job the client submits can be performed by this one object, on
+//	behalf of the other components of the client application that need to log in an
+//	acitivity.
 type ClientLoggingObject struct {
 	// For logging activity only for a particular submitted job, maps job ID to that
 	//   job file logger.
 	jobFileLoggerMap map[string]log.Logger
 	// For ensuring job log file object dedicated to a particular job ID gets closed
 	//   when job is complete.
-	jobLogFileMap    map[string]os.File
+	jobLogFileMap map[string]os.File
 	// For logging all client activity throughout current session on os.Stdout.
-	terminalLogger   log.Logger
+	terminalLogger log.Logger
 	// For logging all client activity throughout history of client application use.
 	clientFileLogger log.Logger
-	// Actual file object that logs all client activity history for the 
+	// Actual file object that logs all client activity history for the
 	//   clientFileLogger.  This is closed when client decides to close the
 	//   ClientLoggingObject using the .Close() method.
-	clientLogFile    *os.File
+	clientLogFile *os.File
 	// Protects access to the jobFileLogger map, in case client app is configured to
 	//   submit and track multiple jobs concurrently.
-	mu               sync.Mutex
+	mu sync.Mutex
 }
 
 // Constructor function that creates a terminal logger to log all the activity in the
-//   current client session, as well as a file for logging all historical client 
-//   activity, and also a logger for that client history log file.
+//
+//	current client session, as well as a file for logging all historical client
+//	activity, and also a logger for that client history log file.
 func NewClientLoggingObject(clientLogFilename string) *ClientLoggingObject {
 	terminalLogger := log.NewLogfmtLogger(os.Stdout)
 	terminalLogger = log.NewSyncLogger(terminalLogger)
@@ -52,7 +54,7 @@ func NewClientLoggingObject(clientLogFilename string) *ClientLoggingObject {
 	clientLogFilename = "jobmgr/client/clientlogs/" + clientLogFilename + ".log"
 
 	// Create the client log file object and its logger
-	clientLogFile, err := os.OpenFile(clientLogFilename,os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	clientLogFile, err := os.OpenFile(clientLogFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 	if err != nil {
 		panic(err)
 	}
@@ -71,39 +73,44 @@ func NewClientLoggingObject(clientLogFilename string) *ClientLoggingObject {
 	}
 }
 
-// Method of the ClientLoggingObject that is used for simultaneously logging into the 
-//   terminalLogger and the clientFileLogger activity done on the scope of the entire
-//   client application.  This will be on INFO level.
+// Method of the ClientLoggingObject that is used for simultaneously logging into the
+//
+//	terminalLogger and the clientFileLogger activity done on the scope of the entire
+//	client application.  This will be on INFO level.
 func (clo *ClientLoggingObject) ClientLogInfo(key, value, message string) {
 	level.Info(clo.terminalLogger).Log(key, value, "message", message)
 	level.Info(clo.clientFileLogger).Log(key, value, "message", message)
 }
 
 // Method of the ClientLoggingObject that is used for simultaneously logging into the
-//   terminalLogger and the clientFileLogger activity done on the scope of the entire
-//   client application.  This will be on WARN level.
+//
+//	terminalLogger and the clientFileLogger activity done on the scope of the entire
+//	client application.  This will be on WARN level.
 func (clo *ClientLoggingObject) ClientLogWarn(key, value, message string) {
 	level.Warn(clo.terminalLogger).Log(key, value, "message", message)
 	level.Warn(clo.clientFileLogger).Log(key, value, "message", message)
 }
 
 // Method of the ClientLoggingObject that is used for simultaneously logging into the
-//   terminalLogger and the clientFileLogger activity done on the scope of the entire
-//   client application.  This will be on ERROR level.
+//
+//	terminalLogger and the clientFileLogger activity done on the scope of the entire
+//	client application.  This will be on ERROR level.
 func (clo *ClientLoggingObject) ClientLogError(key, value, message string) {
 	level.Error(clo.terminalLogger).Log(key, value, "error", message)
 	level.Error(clo.clientFileLogger).Log(key, value, "error", message)
 }
 
-// Method of the ClientLoggingObject thay is used for closing any resources used by the 
-//   object that need closing before the client session is exited.  Particularly used 
-//   for closing the clientLogFile that is used for the clientFileLogger object.
+// Method of the ClientLoggingObject thay is used for closing any resources used by the
+//
+//	object that need closing before the client session is exited.  Particularly used
+//	for closing the clientLogFile that is used for the clientFileLogger object.
 func (clo *ClientLoggingObject) Close() {
 	clo.clientLogFile.Close()
 }
 
 // Method of the ClientLoggingObject that is used for creating a new file to log activity
-//   for a particular submitted job, and creating a logger to log job activity on the file.
+//
+//	for a particular submitted job, and creating a logger to log job activity on the file.
 func (clo *ClientLoggingObject) AddJobLog(jobId, jobLogFilename string) {
 	// Create job log file for specific submitted job
 	jobLogFile, err := os.OpenFile(jobLogFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
@@ -121,7 +128,8 @@ func (clo *ClientLoggingObject) AddJobLog(jobId, jobLogFilename string) {
 }
 
 // Method of the ClientLoggingObject that is used for logging INFO-level information
-//   regarding a job (with a given jobId) on the job file log specific to that jobId.
+//
+//	regarding a job (with a given jobId) on the job file log specific to that jobId.
 func (clo *ClientLoggingObject) JobLogInfo(jobId, key, value, message string) {
 	clo.mu.Lock()
 	defer clo.mu.Unlock()
@@ -133,7 +141,8 @@ func (clo *ClientLoggingObject) JobLogInfo(jobId, key, value, message string) {
 }
 
 // Method of the ClientLoggingObject that is used for logging WARN-level information
-//   regarding a job (with a given jobId) on the job file log specific to that jobId.
+//
+//	regarding a job (with a given jobId) on the job file log specific to that jobId.
 func (clo *ClientLoggingObject) JobLogWarn(jobId, key, value, message string) {
 	clo.mu.Lock()
 	defer clo.mu.Unlock()
@@ -145,7 +154,8 @@ func (clo *ClientLoggingObject) JobLogWarn(jobId, key, value, message string) {
 }
 
 // Method of the ClientLoggingObject that is used for logging ERROR-level information
-//   regarding a job (with a given jobId) on the job file log specific to that jobId.
+//
+//	regarding a job (with a given jobId) on the job file log specific to that jobId.
 func (clo *ClientLoggingObject) JobLogError(jobId, key, value, message string) {
 	clo.mu.Lock()
 	defer clo.mu.Unlock()
@@ -156,11 +166,12 @@ func (clo *ClientLoggingObject) JobLogError(jobId, key, value, message string) {
 	level.Error(jobFileLogger).Log(key, value, "message", message)
 }
 
-// Method of the ClientLoggingObject that is used for closing any resources used by the 
-//   specific jobId's job file logger that need closing when job is completed, regardless
-//   of if it ends in success or error, or if job is cancelled or timed out.  Particularly used
-//   for closing the job log file corresponding to the jobId, remove that file from the
-//   jobLogFileMap, and also delete its corresponding job file logger from the jobFileLoggerMap.
+// Method of the ClientLoggingObject that is used for closing any resources used by the
+//
+//	specific jobId's job file logger that need closing when job is completed, regardless
+//	of if it ends in success or error, or if job is cancelled or timed out.  Particularly used
+//	for closing the job log file corresponding to the jobId, remove that file from the
+//	jobLogFileMap, and also delete its corresponding job file logger from the jobFileLoggerMap.
 func (clo *ClientLoggingObject) JobLogClose(jobId string) {
 	delete(clo.jobFileLoggerMap, jobId)
 

--- a/client/client_logger.go
+++ b/client/client_logger.go
@@ -1,0 +1,170 @@
+package client
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+//*************************************************************************************
+// Definition of the ClientLoggingObject struct, which different parts of the client
+//   application (e.g., a ClientRequestObject, a JobCallbackHandler) can send their 
+//   log messages to, to pass responsibility of logging all client activity -- 
+//   including special log files separate from the client terminal and file logs for
+//   each individual submitted job -- to one object.  That way, duplicate log messages
+//   for the client activity terminal and file logs are written here, and even all 
+//   logging for each job the client submits can be performed by this one object, on
+//   behalf of the other components of the client application that need to log in an
+//   acitivity.
+type ClientLoggingObject struct {
+	// For logging activity only for a particular submitted job, maps job ID to that
+	//   job file logger.
+	jobFileLoggerMap map[string]log.Logger
+	// For ensuring job log file object dedicated to a particular job ID gets closed
+	//   when job is complete.
+	jobLogFileMap    map[string]os.File
+	// For logging all client activity throughout current session on os.Stdout.
+	terminalLogger   log.Logger
+	// For logging all client activity throughout history of client application use.
+	clientFileLogger log.Logger
+	// Actual file object that logs all client activity history for the 
+	//   clientFileLogger.  This is closed when client decides to close the
+	//   ClientLoggingObject using the .Close() method.
+	clientLogFile    *os.File
+	// Protects access to the jobFileLogger map, in case client app is configured to
+	//   submit and track multiple jobs concurrently.
+	mu               sync.Mutex
+}
+
+// Constructor function that creates a terminal logger to log all the activity in the
+//   current client session, as well as a file for logging all historical client 
+//   activity, and also a logger for that client history log file.
+func NewClientLoggingObject(clientLogFilename string) *ClientLoggingObject {
+	terminalLogger := log.NewLogfmtLogger(os.Stdout)
+	terminalLogger = log.NewSyncLogger(terminalLogger)
+	terminalLogger = level.NewFilter(terminalLogger, level.AllowInfo())
+	terminalLogger = log.With(terminalLogger, "time", log.DefaultTimestampUTC)
+
+	// Add filepath to clientlogs directory for the whole job log file path
+	clientLogFilename = "jobmgr/client/clientlogs/" + clientLogFilename + ".log"
+
+	// Create the client log file object and its logger
+	clientLogFile, err := os.OpenFile(clientLogFilename,os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		panic(err)
+	}
+
+	clientFileLogger := log.NewLogfmtLogger(clientLogFile)
+	clientFileLogger = log.NewSyncLogger(clientFileLogger)
+	clientFileLogger = level.NewFilter(clientFileLogger, level.AllowInfo())
+	clientFileLogger = log.With(clientFileLogger, "time", log.DefaultTimestampUTC)
+
+	return &ClientLoggingObject{
+		jobFileLoggerMap: make(map[string]log.Logger),
+		jobLogFileMap:    make(map[string]os.File),
+		terminalLogger:   terminalLogger,
+		clientFileLogger: clientFileLogger,
+		clientLogFile:    clientLogFile,
+	}
+}
+
+// Method of the ClientLoggingObject that is used for simultaneously logging into the 
+//   terminalLogger and the clientFileLogger activity done on the scope of the entire
+//   client application.  This will be on INFO level.
+func (clo *ClientLoggingObject) ClientLogInfo(key, value, message string) {
+	level.Info(clo.terminalLogger).Log(key, value, "message", message)
+	level.Info(clo.clientFileLogger).Log(key, value, "message", message)
+}
+
+// Method of the ClientLoggingObject that is used for simultaneously logging into the
+//   terminalLogger and the clientFileLogger activity done on the scope of the entire
+//   client application.  This will be on WARN level.
+func (clo *ClientLoggingObject) ClientLogWarn(key, value, message string) {
+	level.Warn(clo.terminalLogger).Log(key, value, "message", message)
+	level.Warn(clo.clientFileLogger).Log(key, value, "message", message)
+}
+
+// Method of the ClientLoggingObject that is used for simultaneously logging into the
+//   terminalLogger and the clientFileLogger activity done on the scope of the entire
+//   client application.  This will be on ERROR level.
+func (clo *ClientLoggingObject) ClientLogError(key, value, message string) {
+	level.Error(clo.terminalLogger).Log(key, value, "error", message)
+	level.Error(clo.clientFileLogger).Log(key, value, "error", message)
+}
+
+// Method of the ClientLoggingObject thay is used for closing any resources used by the 
+//   object that need closing before the client session is exited.  Particularly used 
+//   for closing the clientLogFile that is used for the clientFileLogger object.
+func (clo *ClientLoggingObject) Close() {
+	clo.clientLogFile.Close()
+}
+
+// Method of the ClientLoggingObject that is used for creating a new file to log activity
+//   for a particular submitted job, and creating a logger to log job activity on the file.
+func (clo *ClientLoggingObject) AddJobLog(jobId, jobLogFilename string) {
+	// Create job log file for specific submitted job
+	jobLogFile, err := os.OpenFile(jobLogFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create logger to log leveled information on the job log file
+	jobFileLogger := log.NewLogfmtLogger(jobLogFile)
+	jobFileLogger = level.NewFilter(jobFileLogger, level.AllowInfo())
+
+	// Add job file logger to jobFileLoggerMap, mapped to jobId given by the
+	//   JobExecutor service on the server side.
+	clo.jobFileLoggerMap[jobId] = jobFileLogger
+}
+
+// Method of the ClientLoggingObject that is used for logging INFO-level information
+//   regarding a job (with a given jobId) on the job file log specific to that jobId.
+func (clo *ClientLoggingObject) JobLogInfo(jobId, key, value, message string) {
+	clo.mu.Lock()
+	defer clo.mu.Unlock()
+	jobFileLogger, exists := clo.jobFileLoggerMap[jobId]
+	if !exists {
+		panic(fmt.Sprintf("method ClientLoggingObject.JobLogInfo: jobFileLogger for job ID %s doesn't exist", jobId))
+	}
+	level.Info(jobFileLogger).Log(key, value, "message", message)
+}
+
+// Method of the ClientLoggingObject that is used for logging WARN-level information
+//   regarding a job (with a given jobId) on the job file log specific to that jobId.
+func (clo *ClientLoggingObject) JobLogWarn(jobId, key, value, message string) {
+	clo.mu.Lock()
+	defer clo.mu.Unlock()
+	jobFileLogger, exists := clo.jobFileLoggerMap[jobId]
+	if !exists {
+		panic(fmt.Sprintf("method ClientLoggingObject.JobLogWarn: jobFileLogger for job ID %s doesn't exist", jobId))
+	}
+	level.Warn(jobFileLogger).Log(key, value, "message", message)
+}
+
+// Method of the ClientLoggingObject that is used for logging ERROR-level information
+//   regarding a job (with a given jobId) on the job file log specific to that jobId.
+func (clo *ClientLoggingObject) JobLogError(jobId, key, value, message string) {
+	clo.mu.Lock()
+	defer clo.mu.Unlock()
+	jobFileLogger, exists := clo.jobFileLoggerMap[jobId]
+	if !exists {
+		panic(fmt.Sprintf("method ClientLoggingObject.JobLogError: jobFileLogger for job ID %s doesn't exist", jobId))
+	}
+	level.Error(jobFileLogger).Log(key, value, "message", message)
+}
+
+// Method of the ClientLoggingObject that is used for closing any resources used by the 
+//   specific jobId's job file logger that need closing when job is completed, regardless
+//   of if it ends in success or error, or if job is cancelled or timed out.  Particularly used
+//   for closing the job log file corresponding to the jobId, remove that file from the
+//   jobLogFileMap, and also delete its corresponding job file logger from the jobFileLoggerMap.
+func (clo *ClientLoggingObject) JobLogClose(jobId string) {
+	delete(clo.jobFileLoggerMap, jobId)
+
+	jobLogFile := clo.jobLogFileMap[jobId]
+	jobLogFile.Close()
+	delete(clo.jobLogFileMap, jobId)
+}

--- a/client/client_logger.go
+++ b/client/client_logger.go
@@ -51,7 +51,7 @@ func NewClientLoggingObject(clientLogFilename string) *ClientLoggingObject {
 	terminalLogger = log.With(terminalLogger, "time", log.DefaultTimestampUTC)
 
 	// Add filepath to clientlogs directory for the whole job log file path
-	clientLogFilename = "jobmgr/client/clientlogs/" + clientLogFilename + ".log"
+	clientLogFilename = "jobmgr/client/clientlogs/" + clientLogFilename
 
 	// Create the client log file object and its logger
 	clientLogFile, err := os.OpenFile(clientLogFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)

--- a/client/client_request.go
+++ b/client/client_request.go
@@ -1,0 +1,379 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"capnproto.org/go/capnp/v3/rpc"
+	"github.com/astronomical3/jobmgr/jobmgrcapnp"
+)
+
+// ****************************************************************************************
+// Definition of the ClientRequestObject that will actually submit the requested job into
+//
+//	the Job Manager service (aka its Job Executor service), and query and/or cancel the
+//	job.
+type ClientRequestObject struct {
+	address            string
+	port               string
+	timeout            int
+	regConn            net.Conn
+	rpcConn            *rpc.Conn
+	jobSubmission      jobmgrcapnp.JobSubmitInfo
+	jobName            string
+	process            string
+	jobMgrCap          jobmgrcapnp.JobExecutor
+	jobQueryCancel     jobmgrcapnp.JobQueryCancel
+	jobCallbackHandler JobCallbackHandler
+	jobCallbackCap     jobmgrcapnp.JobCallback
+	clientLogger       *ClientLoggingObject
+}
+
+// Constructor function for creating a new ClientRequestObject.
+func NewRequest(jobSubmission jobmgrcapnp.JobSubmitInfo, address, port string, timeout int, clientLogger *ClientLoggingObject) *ClientRequestObject {
+	return &ClientRequestObject{
+		jobSubmission: jobSubmission,
+		address:       address,
+		port:          port,
+		timeout:       timeout,
+		clientLogger:  clientLogger,
+	}
+}
+
+// Connects to the server, and also creates a JobCallbackHandler and a jobmgrcapnp.JobCallback
+//
+//	capability to return when it submits the job.
+func (req *ClientRequestObject) ConnectToServer() error {
+	req.jobName, _ = req.jobSubmission.JobName()
+	req.process, _ = req.jobSubmission.Process()
+	req.clientLogger.ClientLogInfo(
+		"object",
+		"ClientRequestObject",
+		fmt.Sprintf(
+			"Client request stub created for job '%s', which will run process '%s'. Now dialing up to Cap'n Proto Job Manager server",
+			req.jobName,
+			req.process,
+		),
+	)
+
+	max_tries := 3
+	var err error
+	for i := 0; i < max_tries; i++ {
+		req.regConn, err = net.Dial("tcp", net.JoinHostPort(req.address, req.port))
+		if err != nil {
+			req.clientLogger.ClientLogError(
+				"method",
+				"ClientRequestObject.ConnectToServer",
+				fmt.Sprintf(
+					"Error in dialing to Cap'n Proto Job Manager server: %v",
+					err,
+				),
+			)
+			if i == (max_tries - 1) {
+				// Connection fails on last retry
+				req.clientLogger.ClientLogError(
+					"method",
+					"ClientRequestObject.ConnectToServer",
+					"All dialing tries to server failed.",
+				)
+				// If connection fails on last retry, be sure to close all resources
+				//   the ClientRequestObject uses (i.e., server connections, resources
+				//   of the ClientLoggingObject).
+				req.Close()
+				return err
+			}
+		} else {
+			// If dial is successful, break from for loop and set up RPC connection below.
+			break
+		}
+	}
+
+	req.clientLogger.ClientLogInfo(
+		"method",
+		"ClientRequestObject.ConnectToServer",
+		"Dialing is successful.  RPC stream connection to server is being created now...",
+	)
+	req.rpcConn = rpc.NewConn(rpc.NewStreamTransport(req.regConn), nil)
+	req.clientLogger.ClientLogInfo(
+		"method",
+		"ClientRequestObject.ConnectToServer",
+		"RPC stream connection to server is created",
+	)
+	req.jobMgrCap = jobmgrcapnp.JobExecutor(req.rpcConn.Bootstrap(context.Background()))
+	req.clientLogger.ClientLogInfo(
+		"method",
+		"ClientRequestObject.ConnectToServer",
+		"Bootstrap jobmgrcapnp.JobExecutor service capability received from the Job Manager server",
+	)
+
+	// Create a new JobCallbackHandler that the client itself will use to log specific job info in all
+	//   of the logs (client activity and job-specific logs), using its RPCs.
+	req.jobCallbackHandler = NewJobCallbackHandler(req.jobName, req.process, req.clientLogger)
+	req.clientLogger.ClientLogInfo(
+		"method",
+		"ClientRequestObject.ConnectToServer",
+		fmt.Sprintf(
+			"A new JobCallbackHandler has been created for job '%s', which will run process '%s'.",
+			req.jobName,
+			req.process,
+		),
+	)
+
+	// Create a new JobCallback capability that the client will use to send to the server.  Server will
+	//   use this capability to call this capability's RPCs and return information to store and log
+	//   regarding the specific job.
+	req.jobCallbackCap = jobmgrcapnp.JobCallback_ServerToClient(req.jobCallbackHandler)
+	req.clientLogger.ClientLogInfo(
+		"method",
+		"ClientRequestObject.ConnectToServer",
+		"A new JobCallback capability has also been created for the Cap'n Proto Job Manager server to interact with the JobCallbackHandler during submission and execution of the job.",
+	)
+
+	return nil
+}
+
+// Submits the job through the jobMgrCap capability's SubmitJob() RPC, and receives back, stores, and uses a
+//   JobQueryCancel capability to query and/or cancel the submitted job.
+func (req *ClientRequestObject) SubmitJob() error {
+	defer req.Close()
+
+	req.clientLogger.ClientLogInfo(
+		"method",
+		"ClientRequestObject.SubmitJob",
+		fmt.Sprintf(
+			"Now submitting job '%s' which will run process '%s' by calling the JobExecutor_submitJob RPC.",
+			req.jobName,
+			req.process,
+		),
+	)
+
+	// Submit the job, wait for job to submit and for client to get the jobmgrcapnp.JobQueryCancel object.
+	rpcCtx := context.Background()
+	// Get promise of submitting the job
+	submitJobPromise, submitJobPromRel := req.jobMgrCap.SubmitJob(
+		rpcCtx,
+		func(p jobmgrcapnp.JobExecutor_submitJob_Params) error {
+			jobInfoParErr := p.SetJobinfo(req.jobSubmission)
+			if jobInfoParErr != nil {
+				return jobInfoParErr
+			}
+			jobCallbackParErr := p.SetCallback(req.jobCallbackCap)
+			if jobCallbackParErr != nil {
+				return jobInfoParErr
+			}
+			return nil
+		},
+	)
+	defer submitJobPromRel()
+	// Use promise of submitting the job to now actually submit the job and receive back
+	//   a results struct with an actual JobQueryCancel to control the newly submitted job.
+	submitJobResults, err := submitJobPromise.Struct()
+	if err != nil {
+		req.clientLogger.ClientLogError(
+			"method",
+			"ClientRequestObject.SubmitJob",
+			fmt.Sprintf(
+				"Client unable to submit job '%s' with process '%s' into Job Manager service: %v",
+				req.jobName,
+				req.process,
+				err,
+			),
+		)
+		return err
+	}
+	// Actual JobQueryCancel capability is received.
+	req.jobQueryCancel = submitJobResults.Jobquery()
+
+	req.clientLogger.ClientLogInfo(
+		"method",
+		"ClientRequestObject.SubmitJob",
+		fmt.Sprintf(
+			"Client has now successfully submitted job '%s' with process '%s'.  Client has received back from the Job Manager server a jobmgrcapnp.JobQueryCancel object.  Now monitoring the job...",
+			req.jobName,
+			req.process,
+		),
+	)
+
+	// Setup of local client job timeout context, jobCtx
+	var jobCtx context.Context
+	var jobCancel context.CancelFunc
+	if req.timeout <= 0 {
+		jobCtx = context.Background()
+		jobCancel = nil
+	} else {
+		jobCtx, jobCancel = context.WithTimeout(context.Background(), time.Duration(req.timeout) * time.Second)
+	}
+	defer jobCancel()
+
+	// Set up of job query/monitoring ticker
+	queryInterval := 500 * time.Millisecond
+	queryTicker := time.NewTicker(queryInterval)
+	defer queryTicker.Stop()
+
+	// Goroutine for periodically querying the job.  During the query (aka monitoring) procedure,
+	//   any logging of the job activity is performed from this request stub's associated jobCallbackHandler,
+	//   which handles RPC calls from the Job Manager server (sent via a req.jobCallbackCap client capability
+	//   to interact with this handler).
+	go func() {
+		// Client calls jobQueryCancel.QueryJob() to get promise of whether job is still active or not.
+		jobIsActivePromise, jqRel := req.jobQueryCancel.QueryJob(
+			context.Background(),
+			nil,
+		)
+		defer jqRel()
+		for {
+			select {
+			case <-jobCtx.Done():
+				// Indicates that the client's maximum wait time for the job to complete has reached or exceeded,
+				//   and job needs to be cancelled (that is, client interference is needed).
+				// Automatically ignored if jobCtx == context.Background()
+				//***********************************************************************************************
+				// Use req.clientLogger to log that the jobCtx has timed out, and the job will be cancelled using
+				//   req.jobQueryCancel.CancelJob() RPC.
+				req.clientLogger.ClientLogInfo(
+					"method",
+					"ClientRequestObject.SubmitJob",
+					fmt.Sprintf(
+						"Client has timed out for completion of '%s' with process '%s'.  Client is now about to call the CancelJob() RPC from its req.jobQueryCancel capability to cancel job.",
+						req.jobName,
+						req.process,
+					),
+				)
+				// Use req.jobQueryCancel.CancelJob() RPC to cancel the submitted job.  This RPC should also send to
+				//   the req.jobCallbackHandler a final log message that will be sent to the req.clientLogger to add
+				//   to its client activity log and job activity log by calling the sent capability's jobCancelled() 
+				//   RPC.
+				jobIsCancelledPromise, jobIsCancRel := req.jobQueryCancel.CancelJob(
+					context.Background(),
+					nil,
+				)
+				defer jobIsCancRel()
+				jobIsCancelled, err := jobIsCancelledPromise.Struct()
+				if err != nil {
+					req.clientLogger.ClientLogError(
+						"method",
+						"ClientRequestObject.SubmitJob",
+						fmt.Sprintf(
+							"Error in receiving job cancellation signal for job '%s' running process '%s' using JobQueryCancel.CancelJob RPC: %v",
+							req.jobName,
+							req.process,
+							err,
+						),
+					)
+				}
+				req.clientLogger.ClientLogInfo(
+					"method",
+					"ClientRequestObject.SubmitJob",
+					fmt.Sprintf(
+						"Checking if CancelJob() RPC successfully cancelled the job: %v",
+						jobIsCancelled.Cancelled(),
+					),
+				)
+				// Goroutine returns/exits.
+				return
+			case <-req.jobCallbackHandler.doneChan:
+				// Indicates that the job has succeeded or failed on its own, without any client 
+				//   interference.
+				//********************************************************************************
+				// Use req.clientLogger to log query process exit.
+				req.clientLogger.ClientLogInfo(
+					"method",
+					"ClientRequestObject.SubmitJob",
+					fmt.Sprintf(
+						"Job '%s' with process '%s' has completed without any client interference for cancellation of the job.",
+						req.jobName,
+						req.process,
+					),
+				)
+				// Goroutine returns/exits.
+				return
+			case <-queryTicker.C:
+				// Empty, means query just outside the select statement is called.
+			}
+			// Query to the job is made using the promise recieved at beginning of query process.
+			jobIsActive, err := jobIsActivePromise.Struct()
+			if err != nil {
+				req.clientLogger.ClientLogError(
+					"method",
+					"ClientRequestObject.SubmitJob",
+					fmt.Sprintf(
+						"Error in calling on JobQueryCancel.QueryJob RPC to get active/inactive job status for job '%s' running process '%s': %v",
+						req.jobName,
+						req.process,
+						err,
+					),
+				)
+			}
+			// Get jobIsActive.Active() to print out whether job is actually active or not
+			req.clientLogger.ClientLogInfo(
+				"method",
+				"ClientRequestObject.SubmitJob",
+				fmt.Sprintf(
+					"Checking that job '%s' with process '%s' is still active: %v",
+					req.jobName,
+					req.process,
+					jobIsActive.Active(),
+				),
+			)
+		}
+	}()
+
+	// Main method body, in the meantime, waits for job to be completed (its doneChan to receive a signal), and when
+	//   it gets that signal, checks the status of the job, and logs into the client and job logs an
+	//   appropriate message based on status.
+	<-req.jobCallbackHandler.doneChan
+	// Allow query goroutine to fully process final info and exit completely.
+	time.Sleep(2 * time.Second)
+	// Log into client logs a final message that the job was able to be either successfully cancelled
+	//   by the client, or able to complete on its own.
+	var completionMsg string
+	switch req.jobCallbackHandler.status {
+	case jobmgrcapnp.Status_error:
+		completionMsg = fmt.Sprintf(
+			"Job '%s' with process '%s' completed with errors.",
+			req.jobName,
+			req.process,
+		)
+	case jobmgrcapnp.Status_cancel:
+		completionMsg = fmt.Sprintf(
+			"Job '%s' with process '%s' was successfully cancelled by the client after %d-second timeout.",
+			req.jobName,
+			req.process,
+			req.timeout,
+		)
+	case jobmgrcapnp.Status_success:
+		completionMsg = fmt.Sprintf(
+			"Job '%s' with process '%s' completed successfully.",
+			req.jobName,
+			req.process,
+		)
+	}
+	
+	req.clientLogger.ClientLogInfo(
+		"method",
+		"ClientRequestObject_SubmitJob",
+		completionMsg,
+	)
+
+	// A nil error cancellation indicates the entire job submission, query, and/or cancellation
+	//   procedure has been successful.  There have been no processing errors in any of the
+	//   client's requests within the execution of this method.
+	return nil
+}
+
+// Close any open resources, such as when SubmitJob() method is completed.
+//   Deferred in client code.
+func (req *ClientRequestObject) Close() error {
+	// Client RPC connection obtained in order to close connection.
+	// rpcConn field is changed to nil, and RPC connection is closed.
+	conn := req.rpcConn
+	req.rpcConn = nil
+	conn.Close()
+	// Close the general connection that was wrapped in the RPC connection.
+	req.regConn.Close()
+	// Close all remaining open resources in the req.clientLogger instance.
+	req.clientLogger.Close()
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,13 @@ module github.com/astronomical3/jobmgr
 
 go 1.23.1
 
-require capnproto.org/go/capnp/v3 v3.1.0-alpha.1
+require (
+	capnproto.org/go/capnp/v3 v3.1.0-alpha.1
+	github.com/go-kit/log v0.2.0
+)
 
 require (
 	github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,12 @@ github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381 h1:d5EKgQfRQvO97jn
 github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381/go.mod h1:OU76gHeRo8xrzGJU3F3I1CqX1ekM8dfJw0+wPeMwnp0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-kit/kit v0.13.0 h1:OoneCcHKHQ03LfBpoQCUfCluwd2Vt3ohz+kvbJneZAU=
+github.com/go-kit/kit v0.13.0/go.mod h1:phqEHMMUbyrCFCTgH48JueqrM3md2HcAZ8N3XE4FKDg=
+github.com/go-kit/log v0.2.0 h1:7i2K3eKTos3Vc0enKCfnVcgHh2olr/MyfboYq7cAcFw=
+github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/philhofer/fwd v1.1.2 h1:bnDivRJ1EWPjUIRXV5KfORO897HTbpFAQddBdE8t7Gw=
 github.com/philhofer/fwd v1.1.2/go.mod h1:qkPdfjR2SIEbspLqpe1tO4n5yICnr2DY7mqEx2tUTP0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381 h1:d5EKgQfRQvO97jn
 github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381/go.mod h1:OU76gHeRo8xrzGJU3F3I1CqX1ekM8dfJw0+wPeMwnp0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-kit/kit v0.13.0 h1:OoneCcHKHQ03LfBpoQCUfCluwd2Vt3ohz+kvbJneZAU=
-github.com/go-kit/kit v0.13.0/go.mod h1:phqEHMMUbyrCFCTgH48JueqrM3md2HcAZ8N3XE4FKDg=
 github.com/go-kit/log v0.2.0 h1:7i2K3eKTos3Vc0enKCfnVcgHh2olr/MyfboYq7cAcFw=
 github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=

--- a/jobmgrcapnp/jobmgrcapnp.capnp.go
+++ b/jobmgrcapnp/jobmgrcapnp.capnp.go
@@ -3,12 +3,13 @@
 package jobmgrcapnp
 
 import (
+	context "context"
+
 	capnp "capnproto.org/go/capnp/v3"
 	text "capnproto.org/go/capnp/v3/encoding/text"
 	fc "capnproto.org/go/capnp/v3/flowcontrol"
 	schemas "capnproto.org/go/capnp/v3/schemas"
 	server "capnproto.org/go/capnp/v3/server"
-	context "context"
 )
 
 type Status uint16


### PR DESCRIPTION
I have created the core components for the Job Manager Service's client application.  The main core components are in the jobmgr/client package, and consist of:
1. **ClientRequestObject** -- Most important core component, as this object actually connects to the Job Manager Server, submits the job into the server, and monitors the progress of the job.  Represents submission of one job, so every time a new job needs to be submitted into the service, a new ClientRequestObject is needed.
2. **JobCallbackHandler** -- An object that is used by a job's associated ClientRequestObject to log onto the general client activity logs, as well as the job-specific log, all progress of the job's actual running process that was requested by the client.
3. **ClientLoggingObject** -- An object that simply takes in a log message that a component of the client application wants to add in, and uses the go-kit/log API to format the log message as needed.  Used for ensuring that log messages to the general client activity logs will not need to be repeated for both logs, and also for managing the job-specific logs.

In the jobmgr/client package, I also included a client CLI object definition to demonstrate the overall ease of creating and using the necessary core components needed to submit a job -- in this case, submitting a job using a single command on the command line.  The creation and use of a client CLI object was then demonstrated in the jobmgr/client.go main command file, which serves as the entry point for running a single command-line client that runs one job per command.